### PR TITLE
chore: Add docker-compose.yml for manage MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  mysql:
+    image: mariadb:10.4
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: recognizer
+      MYSQL_PASSWORD: recognizer
+      MYSQL_ROOT_PASSWORD: recognizer-admin
+      MYSQL_USER: recognizer
+    volumes:
+      - mysql-data:/var/lib/mysql
+  adminer:
+    image: adminer
+    ports:
+      - "8080:8080"
+
+volumes:
+  mysql-data:
+    driver: local


### PR DESCRIPTION
Partial solves #3
This PR will enable MariaDB to be used with Docker Compose.
