### PR TITLE
fix: Set cascade to onDelete for foreign keys

### DIFF
--- a/database/migrations/2020_02_28_182327_set_cascade_to_ondelete_for_foreign_key.php
+++ b/database/migrations/2020_02_28_182327_set_cascade_to_ondelete_for_foreign_key.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class SetCascadeToOndeleteForForeignKey extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::table('checklists', function (Blueprint $table) {
+            $table->dropForeign(['user']);
+            $table->foreign('user_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+        });
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->dropForeign(['user']);
+            $table->foreign('user_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+
+            $table->dropForeign(['checklist']);
+            $table->foreign('checklist_id')
+                  ->references('id')
+                  ->on('checklists')
+                  ->onDelete('cascade');
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::table('checklists', function (Blueprint $table) {
+            $table->dropForeign(['users']);
+            $table->foreign('user_id')
+                  ->references('id')
+                  ->on('users');
+        });
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->dropForeign(['users']);
+            $table->foreign('user_id')
+                  ->references('id')
+                  ->on('users');
+            $table->dropForeign(['checklist']);
+            $table->foreign('checklist_id')
+                  ->references('id')
+                  ->on('checklists');
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+}


### PR DESCRIPTION
Resolves #17 
The attachment record will be automated delete by `onDelete` when deleting checklists.