### PR TITLE
refactor: Group use statement

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,12 +1,17 @@
 <?php
 
-return PhpCsFixer\Config::create()
-    ->setFinder(PhpCsFixer\Finder::create()
-        ->exclude([
-            'bootstrap/cache',
-            'storage',
-            'vendor',
-        ])
-        ->in(__DIR__)
-    )
-    ;
+namespace PhpCsFixer;
+
+return Config::create()
+    ->setRules([
+        'single_import_per_statement' => false,
+    ])
+    ->setFinder(
+        Finder::create()
+            ->exclude([
+                'bootstrap/cache',
+                'storage',
+                'vendor',
+            ])
+            ->in(__DIR__)
+    );

--- a/app/Http/Controllers/AttachmentsController.php
+++ b/app/Http/Controllers/AttachmentsController.php
@@ -5,8 +5,7 @@ namespace App\Http\Controllers;
 use App\Attachment;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\{Auth, Storage};
 
 class AttachmentsController extends Controller
 {

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,8 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\{Hash, Validator};
 
 class RegisterController extends Controller
 {

--- a/app/Policies/AttachmentPolicy.php
+++ b/app/Policies/AttachmentPolicy.php
@@ -2,8 +2,7 @@
 
 namespace App\Policies;
 
-use App\Attachment;
-use App\User;
+use App\{Attachment, User};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class AttachmentPolicy

--- a/app/Policies/ChecklistPolicy.php
+++ b/app/Policies/ChecklistPolicy.php
@@ -2,8 +2,7 @@
 
 namespace App\Policies;
 
-use App\Checklist;
-use App\User;
+use App\{Checklist, User};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class ChecklistPolicy

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,10 +2,8 @@
 
 namespace App\Providers;
 
-use App\Attachment;
-use App\Checklist;
-use App\Policies\AttachmentPolicy;
-use App\Policies\ChecklistPolicy;
+use App\{Attachment, Checklist};
+use App\Policies\{AttachmentPolicy, ChecklistPolicy};
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 


### PR DESCRIPTION
https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group

>When the class has nothing after the use import statement, the class closing brace MUST be on the next line after the use import statement.
https://www.php-fig.org/psr/psr-12/#42-using-traits

PHP CS Fixer does not support PSR-12, so disabling `single_import_per_statement` rule.